### PR TITLE
Progress towards parsing full history of 37 CFR 42

### DIFF
--- a/regparser/commands/fill_with_rules.py
+++ b/regparser/commands/fill_with_rules.py
@@ -82,7 +82,7 @@ def fill_with_rules(cfr_title, cfr_part):
 
     derived = [(version.identifier, parent.identifier)
                for version, parent in versions_with_parents
-               if is_derived(version.identifier, deps, tree_dir)]
+               if is_derived(version.identifier, deps, tree_dir) and parent]
     for version_id, parent_id in derived:
         deps.validate_for(tree_dir / version_id)
         if deps.is_stale(tree_dir / version_id):

--- a/regparser/commands/full_issuance.py
+++ b/regparser/commands/full_issuance.py
@@ -40,7 +40,7 @@ def process_xml(notice_xml, cfr_title, cfr_part, version_id):
 @click.argument('cfr_part', type=int)
 @click.argument('version', type=str)
 @click.argument('xml_file_path', type=click.Path(exists=True))
-def import_gpo_cfr(cfr_title, cfr_part, version, xml_file_path):
+def full_issuance(cfr_title, cfr_part, version, xml_file_path):
     """Import the provided XML into a regulation tree, version, and notice."""
     with open(xml_file_path, 'rb') as f:
         notice_xml = NoticeXML(f.read(), xml_file_path)

--- a/regparser/commands/import_gpo_cfr.py
+++ b/regparser/commands/import_gpo_cfr.py
@@ -1,81 +1,47 @@
 import logging
-from datetime import date
 
 import click
 
-from regparser.history.annual import find_volume
 from regparser.history.versions import Version
-from regparser.index import dependency, entry
-from regparser.notice.fake import build as build_fake_notice
+from regparser.index import entry
 from regparser.notice.xml import NoticeXML
-from regparser.tree import xml_parser
+from regparser.tree.xml_parser.reg_text import build_tree
 
 
-_version_id = '{}-annual-{}'.format
 logger = logging.getLogger(__name__)
 
-def load_notice(xml_file_path):
-    """Read the notice from the XML file; fill out any missing fields"""
-    with open(xml_file_path, 'rb') as f:
-        notice_xml = NoticeXML(f.read(), xml_file_path).preprocess()
 
-    return notice_xml
-
-
-def process_if_needed(volume, cfr_part, notice_xml):
-    """Review dependencies; if they're out of date, parse the annual edition
-    into a tree and store that"""
-    version_id = _version_id(volume.year, cfr_part)
-    annual_entry = entry.Annual(volume.title, cfr_part, volume.year)
-    tree_entry = entry.Tree(volume.title, cfr_part, version_id)
-    notice_entry = entry.Notice(version_id)
-
-    deps = dependency.Graph()
-    deps.add(tree_entry, annual_entry)
-    deps.validate_for(tree_entry)
-    if deps.is_stale(tree_entry):
-        tree = xml_parser.reg_text.build_tree(notice_xml.xml)
-        tree_entry.write(tree)
-        notice_entry.write(build_fake_notice(
-            version_id, volume.publication_date, volume.title, cfr_part))
+def regtext_for_part(notice_xml, cfr_title, cfr_part):
+    """Filter to only the REGTEXT in question"""
+    xpath = './/REGTEXT[@TITLE={} and @PART={}]'.format(cfr_title, cfr_part)
+    matches = notice_xml.xpath(xpath)
+    if not matches:
+        logger.warning('No matching REGTEXT in this file')
+    else:
+        if len(matches) > 1:
+            logger.warning('Multiple matching REGTEXTs; using the first')
+        return matches[0]
 
 
-def create_version_entry_if_needed(volume, cfr_part):
-    """Only write the version entry if it doesn't already exist. If we
-    overwrote one, we'd be invalidating all related trees, etc."""
-    version_id = _version_id(volume.year, cfr_part)
-    version_dir = entry.FinalVersion(volume.title, cfr_part)
+def process_xml(notice_xml, cfr_title, cfr_part, version_id):
+    """Parse tree from XML and write the relevant index entries"""
+    notice_xml.derive_where_needed()
+    version = Version(identifier=version_id, effective=notice_xml.effective,
+                      published=notice_xml.published)
+    tree = build_tree(regtext_for_part(notice_xml, cfr_title, cfr_part))
 
-    # removed version_id conditional
-    path_list = [c.path[-1] for c in version_dir.sub_entries()]
-
-    if version_id not in path_list:
-        (version_dir / version_id).write(
-            Version(identifier=version_id, effective=volume.publication_date,
-                    published=volume.publication_date))
+    entry.FinalVersion(cfr_title, cfr_part, version_id).write(version)
+    entry.Tree(cfr_title, cfr_part, version_id).write(tree)
+    entry.Notice(version_id).write(notice_xml)
 
 
 @click.command()
 @click.argument('cfr_title', type=int)
 @click.argument('cfr_part', type=int)
-@click.argument('edition', type=str)
-@click.argument('xml_file_path', type=str)
-def import_gpo_cfr(cfr_title, cfr_part, edition, xml_file_path):
-    """Build a regulation tree for the most recent annual edition. This will
-    also construct a corresponding, empty notice to match. The version will be
-    marked as effective on the date of the last annual edition (which is not
-    likely accurate)"""
-    year, notice = [int(string) for string in edition.split('-')]
-    vol = find_volume(year, cfr_title, cfr_part)
-
-    if vol is None:
-        year -= 1
-        vol = find_volume(year, cfr_title, cfr_part)
-
-    logger.info("Getting current version - %s CFR %s, Year: %s",
-                cfr_title, cfr_part, year)
-
-    create_version_entry_if_needed(vol, cfr_part)
-
-    notice_xml = load_notice(xml_file_path)
-    process_if_needed(vol, cfr_part, notice_xml)
+@click.argument('version', type=str)
+@click.argument('xml_file_path', type=click.Path(exists=True))
+def import_gpo_cfr(cfr_title, cfr_part, version, xml_file_path):
+    """Import the provided XML into a regulation tree, version, and notice."""
+    with open(xml_file_path, 'rb') as f:
+        notice_xml = NoticeXML(f.read(), xml_file_path)
+    process_xml(notice_xml, cfr_title, cfr_part, version)

--- a/regparser/commands/import_notice.py
+++ b/regparser/commands/import_notice.py
@@ -17,7 +17,7 @@ def parse_notice(xml_file_path):
     if has_requirements(notice_xml):
         notice_xml.derive_where_needed()
 
-    return notice_xml
+        return notice_xml
 
 
 def has_requirements(notice_xml):

--- a/regparser/index/dependency.py
+++ b/regparser/index/dependency.py
@@ -110,8 +110,7 @@ class Graph(object):
         logger.debug("Validating dependencies for %r", key)
         for dependency in self.dependencies(key):
             if self.node(dependency).get('stale'):
-                pass
-                # raise Missing(key, self.node(dependency)['stale'])
+                raise Missing(key, self.node(dependency)['stale'])
 
     def is_stale(self, entry):
         """Determine if a file needs to be rebuilt"""

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -32,20 +32,22 @@ def get_reg_part(reg_doc):
     potential_parts = []
     potential_parts.extend(
         # FR notice
-        node.attrib['PART'] for node in reg_doc.xpath('//REGTEXT'))
+        node.attrib['PART']
+        for node in reg_doc.xpath('self::REGTEXT|.//REGTEXT'))
     potential_parts.extend(
         # e-CFR XML, under PART/EAR
         node.text.replace('Pt.', '').strip()
-        for node in reg_doc.xpath('//PART/EAR')
+        for node in reg_doc.xpath('self::PART/EAR|.//PART/EAR')
         if 'Pt.' in node.text)
     potential_parts.extend(
         # e-CFR XML, under FDSYS/HEADING
         node.text.replace('PART', '').strip()
-        for node in reg_doc.xpath('//FDSYS/HEADING')
+        for node in reg_doc.xpath('self::FDSYS/HEADING|.//FDSYS/HEADING')
         if 'PART' in node.text)
     potential_parts.extend(
         # e-CFR XML, under FDSYS/GRANULENUM
-        node.text.strip() for node in reg_doc.xpath('//FDSYS/GRANULENUM'))
+        node.text.strip() for node in reg_doc.xpath(
+            'self::FDSYS/GRANULENUM|.//FDSYS/GRANULENUM'))
     potential_parts = [p for p in potential_parts if p.strip()]
 
     if potential_parts:
@@ -54,7 +56,7 @@ def get_reg_part(reg_doc):
 
 def get_title(reg_doc):
     """ Extract the title of the regulation. """
-    parent = reg_doc.xpath('//PART/HD')[0]
+    parent = reg_doc.xpath('.//PART/HD')[0]
     title = parent.text
     return title
 
@@ -83,7 +85,7 @@ def build_tree(reg_xml):
 
     tree = Node("", [], [reg_part], title)
 
-    part = reg_xml.xpath('//PART')[0]
+    part = reg_xml.xpath('.//PART')[0]
 
     # Build a list of SUBPARTs, then pull SUBJGRPs into that list:
     subpart_and_subjgrp_xmls = []


### PR DESCRIPTION
Doesn't get us entirely there, but sets up the `full_issuance` command to derive a full tree from `2012-17900`.

Usage:
```bash
eregs full_issuance 37 42 2012-17900
eregs --debug pipeline 37 42 some-output-dir
```

More context at eregs/regulations-parser#320