### PR TITLE
Account for subpart adds with multiple paragraphs

### DIFF
--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -193,7 +193,7 @@ def create_field_amendment(label, amendment):
     return nodes
 
 
-def create_add_amendment(amendment):
+def create_add_amendment(amendment, subpart_label=None):
     """ An amendment comes in with a whole tree structure. We break apart the
     tree here (this is what flatten does), convert the Node objects to JSON
     representations. This ensures that each amendment only acts on one node.
@@ -204,8 +204,11 @@ def create_add_amendment(amendment):
     flatten_tree(nodes_list, amendment['node'])
     changes = []
     for node in nodes_list:
-        if node.label == amendment['node'].label:   # is root
-            parent_label = amendment.get('parent_label')
+        is_root = node.label == amendment['node'].label
+        if is_root:
+            parent_label = amendment.get('parent_label') or subpart_label
+        elif len(node.label) == 2:
+            parent_label = subpart_label
         else:
             parent_label = None
         changes.append(format_node(node, amendment, parent_label))
@@ -249,9 +252,8 @@ def create_subpart_amendment(subpart_node):
     amendment = {
         'node': subpart_node,
         'action': 'POST',
-        'extras': {'parent_label': subpart_node.label}
     }
-    return create_add_amendment(amendment)
+    return create_add_amendment(amendment, subpart_node.label)
 
 
 def flatten_tree(node_list, node):


### PR DESCRIPTION
Previously, we had tacked on the "parent_label" to _all_ subnodes of a subpart
addition. This led all of the nodes to be added at the section level, which
would not only be inaccurate, but lead to an explosion as we couldn't compare
sections (ints) with paragraphs (strings) when sorting.

This should fix that issue; it'll need to be cleaned up a bit and tests added
to head back upstream, but should get you further along.