### PR TITLE
Create preprocessor to move SUBPARTs when needed

### DIFF
--- a/regparser/tree/xml_parser/preprocessors.py
+++ b/regparser/tree/xml_parser/preprocessors.py
@@ -430,3 +430,17 @@ class ImportCategories(PreProcessorBase):
                 next_el = iterator.getnext()
                 category_el.append(iterator)
                 iterator = next_el
+
+
+class MoveSubpart(PreProcessorBase):
+    """Account for SUBPART tags being outside their intended CONTENTS"""
+    def transform(self, xml):
+        for subpart in xml.xpath('//SUBPART'):
+            following = subpart.getnext()
+            if following is not None and following.tag == 'CONTENTS':
+                for content_child in following:
+                    if content_child.tag != 'SUBPART':
+                        subpart.append(content_child)
+                    else:
+                        break
+                following.insert(0, subpart)

--- a/settings.py
+++ b/settings.py
@@ -118,6 +118,7 @@ PREPROCESSORS = plugins.extend_list('eregs_ns.parser.preprocessors', [
     "regparser.tree.xml_parser.preprocessors.AtfI50032",
     "regparser.tree.xml_parser.preprocessors.AtfI50031",
     "regparser.tree.xml_parser.preprocessors.ImportCategories",
+    "regparser.tree.xml_parser.preprocessors.MoveSubpart",
 ])
 
 # Which layers are to be generated, keyed by document type. The ALL key is


### PR DESCRIPTION
The Federal Register notice XML often has little bugs; in this case:

```
<HD SOURCE="HED">
  PART 42—TRIAL PRACTICE BEFORE THE PATENT TRIAL AND APPEAL BOARD
</HD>
<SUBPART>
  <HD SOURCE="HED">Subpart A—Trial Practice and Procedure</HD>
</SUBPART>
<CONTENTS>
  <SECHD>Sec.</SECHD>
  <HD SOURCE="HD1">General</HD>
  <SECTNO>42.1</SECTNO>
  <SUBJECT>Policy.</SUBJECT>
  <SECTNO>42.2</SECTNO>
...
```

Should instead have the SUBPART tag inside the CONTENTS (as in "table of"):
```
<HD SOURCE="HED">
  PART 42—TRIAL PRACTICE BEFORE THE PATENT TRIAL AND APPEAL BOARD
</HD>
<CONTENTS>
  <SUBPART>
    <HD SOURCE="HED">Subpart A—Trial Practice and Procedure</HD>
    <SECHD>Sec.</SECHD>
    <HD SOURCE="HD1">General</HD>
    <SECTNO>42.1</SECTNO>
    <SUBJECT>Policy.</SUBJECT>
    <SECTNO>42.2</SECTNO>
...
```